### PR TITLE
Add end to end test with KinD in Github Actions

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -35,10 +35,10 @@ jobs:
           kubectl: '1.18.2'
           kustomize: '3.8.1'
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0-rc1
+        uses: engineerd/setup-kind@v0.4.0
         with:
           version: v0.8.1
-          cluster_name: e2e-test
+          name: e2e-test
       - name: Context logging
         run: |
           kubectl=${{steps.setup.outputs.kubectl-path}}
@@ -61,3 +61,5 @@ jobs:
       - name: Await job
         run: |
           kubectl wait --for=condition=complete --timeout=5m job/client-server-job
+      - name: Delete kind cluster
+        run: kind delete cluster e2e-test

--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -35,6 +35,10 @@ jobs:
         with:
           kubectl: '1.18.2'
           kustomize: '3.8.1'
+      - name: Update path
+        run: |
+          echo "::add-path::$(dirname "${{steps.setup.outputs.kubectl-path}}")"
+          echo "::add-path::$(dirname "${{steps.setup.outputs.kustomize-path}}")"
       - name: Create kind cluster
         uses: engineerd/setup-kind@v0.4.0
         with:
@@ -42,11 +46,6 @@ jobs:
           name: e2e-test
       - name: Print Context
         run: |
-          kubectl=${{steps.setup.outputs.kubectl-path}}
-          cp "${kubectl}" /usr/local/bin/kubectl
-          kustomize=${{steps.setup.outputs.kustomize-path}}
-          cp "${kustomize}" /usr/local/bin/kustomize
-
           kubectl version --client
           kustomize version
 

--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -39,27 +39,29 @@ jobs:
         with:
           version: v0.8.1
           name: e2e-test
-      - name: Context logging
+      - name: Print Context
         run: |
           kubectl=${{steps.setup.outputs.kubectl-path}}
           kustomize=${{steps.setup.outputs.kustomize-path}}
 
-          ${kubectl} version --client
-          ${kustomize} version
+          "${kubectl}" version --client
+          "${kustomize}" version
 
-          kubectl cluster-info
-          kubectl get pods -n kube-system
-          echo "current-context:" "$(kubectl config current-context)"
+          "${kubectl}" cluster-info
+          "${kubectl}" get pods -n kube-system
+          echo "current-context:" "$("${kubectl}" config current-context)"
           echo "environment-kubeconfig:" "${KUBECONFIG}"
       - name: Apply job
         env:
           TEST_PATH: ci/e2e-test/client-server
         run: |
+          kustomize=${{steps.setup.outputs.kustomize-path}}
           cd "${TEST_PATH}"
-          kustomize edit set image karlkfi/kubexit=karlkfi/kubexit:latest
-          kustomize build . | kubectl apply -f -
+          "${kustomize}" edit set image karlkfi/kubexit=karlkfi/kubexit:latest
+          "${kustomize}" build . | kubectl apply -f -
       - name: Await job
         run: |
-          kubectl wait --for=condition=complete --timeout=5m job/client-server-job
+          kubectl=${{steps.setup.outputs.kubectl-path}}
+          "${kubectl}" wait --for=condition=complete --timeout=5m job/client-server-job
       - name: Delete kind cluster
         run: kind delete cluster e2e-test

--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -35,10 +35,12 @@ jobs:
         with:
           kubectl: '1.18.2'
           kustomize: '3.8.1'
+          jq: 'latest'
       - name: Update path
         run: |
           echo "::add-path::$(dirname "${{steps.setup.outputs.kubectl-path}}")"
           echo "::add-path::$(dirname "${{steps.setup.outputs.kustomize-path}}")"
+          echo "::add-path::$(dirname "${{steps.setup.outputs.jq-path}}")"
       - name: Create kind cluster
         uses: engineerd/setup-kind@v0.4.0
         with:
@@ -54,27 +56,9 @@ jobs:
           echo "current-context:" "$(kubectl config current-context)"
           echo "environment-kubeconfig:" "${KUBECONFIG}"
       - name: Apply job
-        env:
-          TEST_PATH: ci/e2e-test/client-server
-        run: |
-          cd "${TEST_PATH}"
-          kustomize edit set image karlkfi/kubexit=karlkfi/kubexit:latest
-          kustomize build . | kubectl apply -f -
+        run: ci/e2e-test/client-server/apply-job.sh
       - name: Await job
-        run: |
-          kubectl wait pod --selector=job-name=client-server-job --for=condition=Initialized --timeout=2m
-          timeout=120
-          SECONDS=0
-          while (( SECONDS < timeout )); do
-            job_status=$(kubectl get pods --selector=job-name=client-server-job -o jsonpath="{.items[*].status.containerStatuses[*].state.terminated.reason}")
-            if [[ "${job_status}" == *"Completed" -o "${job_status}" == *"Error" ]]; then
-              echo "Status: ${job_status}"
-              break
-            fi
-            sleep 2
-          done
-          kubectl logs --selector=job-name=client-server-job --all-containers --tail=-1
-          kubectl get pods --selector=job-name=client-server-job -o yaml
+        run: ci/e2e-test/client-server/await-job.sh
       - name: Delete kind cluster
         if: always()
         run: kind delete cluster --name e2e-test

--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -19,3 +19,45 @@ jobs:
         repository: karlkfi/kubexit
         # Docker Automated Builds handle publishing
         push: false
+  e2e-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build image
+        uses: docker/build-push-action@v1
+        with:
+          repository: karlkfi/kubexit
+          push: false
+      - name: Setup kube tools
+        uses: yokawasa/action-setup-kube-tools@v0.1.0
+        with:
+          kubectl: '1.18.2'
+          kustomize: '3.8.1'
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.0.0
+        with:
+          version: v0.8.1
+          cluster_name: e2e-test
+      - name: Context logging
+        run: |
+          kubectl=${{steps.setup.outputs.kubectl-path}}
+          kustomize=${{steps.setup.outputs.kustomize-path}}
+
+          ${kubectl} version --client
+          ${kustomize} version
+
+          kubectl cluster-info
+          kubectl get pods -n kube-system
+          echo "current-context:" "$(kubectl config current-context)"
+          echo "environment-kubeconfig:" "${KUBECONFIG}"
+      - name: Apply job
+        env:
+          TEST_PATH: ci/e2e-test/client-server
+        run: |
+          cd "${TEST_PATH}"
+          kustomize edit set image karlkfi/kubexit=karlkfi/kubexit:latest
+          kustomize build . | kubectl apply -f -
+      - name: Await job
+        run: |
+          kubectl wait --for=condition=complete --timeout=5m job/client-server-job

--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -35,7 +35,7 @@ jobs:
           kubectl: '1.18.2'
           kustomize: '3.8.1'
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0
+        uses: helm/kind-action@v1.0.0-rc1
         with:
           version: v0.8.1
           cluster_name: e2e-test

--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -30,6 +30,7 @@ jobs:
           repository: karlkfi/kubexit
           push: false
       - name: Setup kube tools
+        id: setup
         uses: yokawasa/action-setup-kube-tools@v0.1.0
         with:
           kubectl: '1.18.2'
@@ -64,4 +65,5 @@ jobs:
           kubectl=${{steps.setup.outputs.kubectl-path}}
           "${kubectl}" wait --for=condition=complete --timeout=5m job/client-server-job
       - name: Delete kind cluster
+        if: always()
         run: kind delete cluster e2e-test

--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -43,27 +43,39 @@ jobs:
       - name: Print Context
         run: |
           kubectl=${{steps.setup.outputs.kubectl-path}}
+          cp "${kubectl}" /usr/local/bin/kubectl
           kustomize=${{steps.setup.outputs.kustomize-path}}
+          cp "${kustomize}" /usr/local/bin/kustomize
 
-          "${kubectl}" version --client
-          "${kustomize}" version
+          kubectl version --client
+          kustomize version
 
-          "${kubectl}" cluster-info
-          "${kubectl}" get pods -n kube-system
-          echo "current-context:" "$("${kubectl}" config current-context)"
+          kubectl cluster-info
+          kubectl get pods -n kube-system
+          echo "current-context:" "$(kubectl config current-context)"
           echo "environment-kubeconfig:" "${KUBECONFIG}"
       - name: Apply job
         env:
           TEST_PATH: ci/e2e-test/client-server
         run: |
-          kustomize=${{steps.setup.outputs.kustomize-path}}
           cd "${TEST_PATH}"
-          "${kustomize}" edit set image karlkfi/kubexit=karlkfi/kubexit:latest
-          "${kustomize}" build . | kubectl apply -f -
+          kustomize edit set image karlkfi/kubexit=karlkfi/kubexit:latest
+          kustomize build . | kubectl apply -f -
       - name: Await job
         run: |
-          kubectl=${{steps.setup.outputs.kubectl-path}}
-          "${kubectl}" wait --for=condition=complete --timeout=5m job/client-server-job
+          kubectl wait pod --selector=job-name=client-server-job --for=condition=Initialized --timeout=2m
+          timeout=120
+          SECONDS=0
+          while (( SECONDS < timeout )); do
+            job_status=$(kubectl get pods --selector=job-name=client-server-job -o jsonpath="{.items[*].status.containerStatuses[*].state.terminated.reason}")
+            if [[ "${job_status}" == *"Completed" -o "${job_status}" == *"Error" ]]; then
+              echo "Status: ${job_status}"
+              break
+            fi
+            sleep 2
+          done
+          kubectl logs --selector=job-name=client-server-job --all-containers --tail=-1
+          kubectl get pods --selector=job-name=client-server-job -o yaml
       - name: Delete kind cluster
         if: always()
-        run: kind delete cluster e2e-test
+        run: kind delete cluster --name e2e-test

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -1,5 +1,5 @@
 ---
-name: Container Image
+name: End-to-End Tests
 
 on:
   pull_request:
@@ -7,27 +7,18 @@ on:
     - master
 
 jobs:
-  # https://help.github.com/en/actions/language-and-framework-guides/publishing-docker-images
-  container-image:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Build & Push to Docker Hub
-      # https://github.com/docker/build-push-action
-      uses: docker/build-push-action@v1
-      with:
-        repository: karlkfi/kubexit
-        # Docker Automated Builds handle publishing
-        push: false
   e2e-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build image
+        # https://help.github.com/en/actions/language-and-framework-guides/publishing-docker-images
+        # https://github.com/docker/build-push-action
         uses: docker/build-push-action@v1
         with:
           repository: karlkfi/kubexit
+          # Docker Automated Builds handle publishing
           push: false
       - name: Setup kube tools
         id: setup
@@ -59,6 +50,8 @@ jobs:
         run: ci/e2e-test/client-server/apply-job.sh
       - name: Await job
         run: ci/e2e-test/client-server/await-job.sh
+      - name: Delete job
+        run: ci/e2e-test/client-server/delete-job.sh
       - name: Delete kind cluster
         if: always()
         run: kind delete cluster --name e2e-test

--- a/ci/e2e-test/client-server/apply-job.sh
+++ b/ci/e2e-test/client-server/apply-job.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail -o posix
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+kustomize edit set image karlkfi/kubexit=karlkfi/kubexit:latest
+kustomize build . | kubectl apply -f -

--- a/ci/e2e-test/client-server/await-job.sh
+++ b/ci/e2e-test/client-server/await-job.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail -o posix
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
+cd "${REPO_ROOT}"
+
+echo "Awaiting Job Init..."
+kubectl wait pod --selector=job-name=client-server-job --for=condition=Initialized --timeout=2m
+
+echo
+echo "Awaiting Job Completed or Error..."
+timeout=120
+SECONDS=0
+while (( SECONDS < timeout )); do
+    job_status="$(kubectl get pods --selector=job-name=client-server-job -o jsonpath="{.items[*].status.containerStatuses[*].state.terminated.reason}")"
+    if [[ "${job_status}" == *"Completed" || "${job_status}" == *"Error" ]]; then
+        echo "Status: ${job_status}"
+        break
+    fi
+    echo "Sleeping 2s..."
+    sleep 2
+done
+
+echo
+echo "Container Logs:"
+kubectl logs --selector=job-name=client-server-job --all-containers --tail=-1
+
+echo
+echo "Pod Respurces:"
+kubectl get pods --selector=job-name=client-server-job -o json | jq '.items[].status'

--- a/ci/e2e-test/client-server/await-job.sh
+++ b/ci/e2e-test/client-server/await-job.sh
@@ -29,3 +29,8 @@ kubectl logs --selector=job-name=client-server-job --all-containers --tail=-1
 echo
 echo "Pod Respurces:"
 kubectl get pods --selector=job-name=client-server-job -o json | jq '.items[].status'
+
+echo "Status: ${job_status}"
+if [[ "${job_status}" == *"Error" ]]; then
+    exit 1
+fi

--- a/ci/e2e-test/client-server/await-job.sh
+++ b/ci/e2e-test/client-server/await-job.sh
@@ -14,7 +14,7 @@ timeout=120
 SECONDS=0
 while (( SECONDS < timeout )); do
     job_status="$(kubectl get pods --selector=job-name=client-server-job -o jsonpath="{.items[*].status.containerStatuses[*].state.terminated.reason}")"
-    if [[ "${job_status}" == *"Completed" || "${job_status}" == *"Error" ]]; then
+    if [[ "${job_status}" == "Completed Completed" || "${job_status}" == *"Error" ]]; then
         echo "Status: ${job_status}"
         break
     fi

--- a/ci/e2e-test/client-server/delete-job.sh
+++ b/ci/e2e-test/client-server/delete-job.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail -o posix
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
+cd "${REPO_ROOT}"
+
+kubectl delete job client-server-job
+
+echo
+echo "Awaiting Pod Deletion..."
+kubectl wait pods --for=delete --selector=job-name=client-server-job --timeout=2m

--- a/ci/e2e-test/client-server/job.yaml
+++ b/ci/e2e-test/client-server/job.yaml
@@ -9,6 +9,7 @@ spec:
       labels:
         app: client-server-job
     spec:
+      serviceAccountName: client-server-job
       restartPolicy: Never
       volumes:
       - name: graveyard

--- a/ci/e2e-test/client-server/job.yaml
+++ b/ci/e2e-test/client-server/job.yaml
@@ -1,0 +1,92 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: client-server-job
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        app: client-server-job
+    spec:
+      restartPolicy: Never
+      volumes:
+      - name: graveyard
+        emptyDir:
+          medium: Memory
+      - name: kubexit
+        emptyDir: {}
+
+      initContainers:
+      - name: kubexit
+        image: karlkfi/kubexit:latest
+        command: ['cp', '/bin/kubexit', '/kubexit/kubexit']
+        volumeMounts:
+        - mountPath: /kubexit
+          name: kubexit
+
+      containers:
+      - name: client
+        image: alpine:3.11
+        command: ['sh', '-c']
+        args:
+        - |
+          set -o errexit -o nounset -o pipefail
+          apk --no-cache add ca-certificates tzdata curl bash
+          /kubexit/kubexit curl -v --fail http://localhost:80/
+        env:
+        - name: KUBEXIT_NAME
+          value: client
+        - name: KUBEXIT_GRAVEYARD
+          value: /graveyard
+        - name: KUBEXIT_BIRTH_DEPS
+          value: server
+        - name: KUBEXIT_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: KUBEXIT_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        volumeMounts:
+        - mountPath: /graveyard
+          name: graveyard
+        - mountPath: /kubexit
+          name: kubexit
+      - name: server
+        image: nginx:1.17-alpine
+        command: ['sh', '-c']
+        args:
+        - |
+          set -o errexit -o nounset -o pipefail
+          sleep 10
+          /kubexit/kubexit nginx -g 'daemon off;'
+        env:
+        - name: KUBEXIT_NAME
+          value: server
+        - name: KUBEXIT_GRAVEYARD
+          value: /graveyard
+        - name: KUBEXIT_DEATH_DEPS
+          value: client
+        volumeMounts:
+        - mountPath: /graveyard
+          name: graveyard
+        - mountPath: /kubexit
+          name: kubexit
+        livenessProbe:
+          tcpSocket:
+            port: 80
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 6
+        readinessProbe:
+          tcpSocket:
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 6

--- a/ci/e2e-test/client-server/kustomization.yaml
+++ b/ci/e2e-test/client-server/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- job.yaml

--- a/ci/e2e-test/client-server/kustomization.yaml
+++ b/ci/e2e-test/client-server/kustomization.yaml
@@ -1,4 +1,7 @@
 resources:
+- service-account.yaml
+- role.yaml
+- role-binding.yaml
 - job.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/ci/e2e-test/client-server/kustomization.yaml
+++ b/ci/e2e-test/client-server/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - job.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: karlkfi/kubexit
+  newName: karlkfi/kubexit
+  newTag: latest

--- a/ci/e2e-test/client-server/role-binding.yaml
+++ b/ci/e2e-test/client-server/role-binding.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: namespace-viewer
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: client-server-job
+  apiGroup: ""
+roleRef:
+  kind: Role
+  name: namespace-viewer
+  apiGroup: rbac.authorization.k8s.io

--- a/ci/e2e-test/client-server/role.yaml
+++ b/ci/e2e-test/client-server/role.yaml
@@ -1,0 +1,9 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: namespace-viewer
+  namespace: default
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]

--- a/ci/e2e-test/client-server/service-account.yaml
+++ b/ci/e2e-test/client-server/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: client-server-job
+  namespace: default


### PR DESCRIPTION
First e2e test will validate the client-server job example to simply validate successful completion of a job with both birth deps and death deps.

This test will use an e2e-test github actions workflow that starts KinD, deploys a job, waits for the job to complete or error, and fail on error, printing status and logs for debugging.

Once this first e2e test works, more can be added later to validate certain failure scenarios.

The first bug found is #3.
Another bug found is that the default service account permissions can't list pods, which is required by kubexit for birth deps.