### PR TITLE
Ensure graceful shutdown on time out while waiting for birth dependencies

### DIFF
--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -75,7 +75,9 @@ func (s *Supervisor) Start() error {
 func (s *Supervisor) Wait() error {
 	defer func() {
 		signal.Reset()
-		close(s.sigCh)
+		if s.sigCh != nil {
+			close(s.sigCh)
+		}
 		if s.shutdownTimer != nil {
 			s.shutdownTimer.Stop()
 		}


### PR DESCRIPTION
fixes #3 

When a time out happens while waiting for birth dependencies, an error occurs while running the `fatalf` function to gracefully shut down the application with an non-zero exit code. This issue is caused by closing a channel that is `nil` at time of exection. This channel is only set when the child proces is actually started, which is not the case if we reach the state in which we time out while waiting for birth dependencies.

After this PR, the application shuts down gracefully and even writes a tombstone as expected:
```
2020-07-30T07:06:43.577364835Z Name: <CONTAINER-NAME-REDACTED>
2020-07-30T07:06:43.577383743Z Graveyard: /kubexit
2020-07-30T07:06:43.577386656Z Tombstone: /kubexit/<CONTAINER-NAME-REDACTED>
2020-07-30T07:06:43.577388839Z Birth Deps: <CONTAINER-NAME-REDACTED>
2020-07-30T07:06:43.577390799Z Death Deps: N/A
2020-07-30T07:06:43.577392790Z Birth Timeout: 1m30s
2020-07-30T07:06:43.577394725Z Grace Period: 30s
2020-07-30T07:06:43.577427123Z Pod Name: <POD-NAME-REDACTED>
2020-07-30T07:06:43.577429274Z Namespace: default
2020-07-30T07:06:43.577431211Z Watching pod updates...
2020-07-30T07:06:43.595384882Z Event Type: ADDED
2020-07-30T07:06:44.314353913Z Event Type: MODIFIED
2020-07-30T07:08:13.577310732Z Error: timed out waiting for birth deps to be ready: 1m30s
2020-07-30T07:08:13.577339763Z Skipping ShutdownNow: child process not running
2020-07-30T07:08:13.577342708Z Waiting for child process to exit...
2020-07-30T07:08:13.577344898Z Pod Watch(<POD-NAME-REDACTED>): done
2020-07-30T07:08:13.578613693Z Child Exited(-1): exec: not started
2020-07-30T07:08:13.578629745Z Updating tombstone: /kubexit/<CONTAINER-NAME-REDACTED>
```