### PR TITLE
Ensure kubexit does not hang when watched pod is ready when started

### DIFF
--- a/cmd/kubexit/main.go
+++ b/cmd/kubexit/main.go
@@ -281,8 +281,8 @@ func onReadyOfAll(birthDeps []string, callback func()) kubernetes.EventHandler {
 
 	return func(event watch.Event) {
 		fmt.Printf("Event Type: %v\n", event.Type)
-		// ignore Added & Deleted (Watch will auto-stop on delete)
-		if event.Type != watch.Modified {
+		// ignore Deleted (Watch will auto-stop on delete)
+		if event.Type == watch.Deleted {
 			return
 		}
 


### PR DESCRIPTION
fixes #6 

If kubexit is started after a birth dependency has already become ready, kubexit never finds out about the ready status of the dependency.

This is because kubexit only re-evaluates the ready status on an modified event, while such an event never occurs if the birth dependency is ready before kubexit started watching.

I fixed this bug by also taking the `Added` event into consideration. This event is always emitted when kubexit starts watching the birth dependencies. If the dependencies are already ready, it will immediatly continue.