### PR TITLE
Ensure tombstones created before kubexit started are read

### DIFF
--- a/cmd/kubexit/main.go
+++ b/cmd/kubexit/main.go
@@ -320,13 +320,11 @@ func onDeathOfAny(deathDeps []string, callback func()) tombstone.EventHandler {
 		deathDepSet[depName] = struct{}{}
 	}
 
-	return func(event fsnotify.Event) {
-		if event.Op&fsnotify.Create != fsnotify.Create && event.Op&fsnotify.Write != fsnotify.Write {
-			// ignore other events
+	return func(graveyard string, name string, op fsnotify.Op) {
+		if op != 0 && op&fsnotify.Create != fsnotify.Create && op&fsnotify.Write != fsnotify.Write {
+			// ignore events other than initial, create and write
 			return
 		}
-		graveyard := filepath.Dir(event.Name)
-		name := filepath.Base(event.Name)
 
 		log.Printf("Tombstone modified: %s\n", name)
 		if _, ok := deathDepSet[name]; !ok {


### PR DESCRIPTION
fixes #8

This commit changes the `Watch` function inside the `tombstone` package to also emit an initial event besides the `fsnotify` events. This initial event is called immediatly when `Watch` is called and the watcher has been setup.

This change allows kubexit to detect tombstones written before kubexit was started. This prevents possible race conditions as described by #8.

In order for this change to work, the `tombstone.EventHandler` type was changed. It now requires a function with 3 arguments: The graveyard, the tombstone and the operation instead of an `fsnotify.Event`. Reason being that the initial event is not an `fsnotify.Event`. The functions implementing a `tombstone.EventHandler` are changed accordingly.

This change on its own introduces a new bug where the tombstone is written as part of an initial event, but the child process will still start because `child.Start()` is being called after the watcher has been setup. To overcome this issue, the shutdown state of the child is tracked in a new flag, which is set if `ShutdownNow()` or `ShutdownWithTimeout()` is executed.