### PR TITLE
Ensure tombstones created before kubexit started are read

### DIFF
--- a/pkg/tombstone/tombstone.go
+++ b/pkg/tombstone/tombstone.go
@@ -166,5 +166,19 @@ func Watch(ctx context.Context, graveyard string, eventHandler EventHandler) err
 	if err != nil {
 		return fmt.Errorf("failed to add watcher: %v", err)
 	}
+
+	files, err := ioutil.ReadDir(graveyard)
+	if err != nil {
+		return fmt.Errorf("failed to read graveyard dir: %v", err)
+	}
+
+	for _, f := range files {
+		event := fsnotify.Event{
+			Name:	filepath.Join(graveyard, f.Name()),
+			Op:		fsnotify.Create,
+		}
+		eventHandler(event)
+	}
+
 	return nil
 }


### PR DESCRIPTION
Fixes #8 
Replaces #9, this should be a better PR with less unneeded refactoring

This commit changes the `Watch` function inside the `tombstone` package to
also emit an fake 'Created' event besides the real `fsnotify` events. This
initial event is send out immediatly when `Watch` is called and the watcher
has been setup.

This change allows kubexit to detect tombstones written before kubexit was
started. This prevents possible race conditions as described by karlkfi#8.

This change on its own introduces a new bug where the tombstone is written
as part of an initial event, but the child process will still start because
`child.Start()` is being called after the watcher has been setup. To overcome
this issue, the shutdown state of the child is tracked in a new flag, which is
set if `ShutdownNow()` or `ShutdownWithTimeout()` is executed.