### PR TITLE
Test process exists before signaling

### DIFF
--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -62,9 +62,12 @@ func (s *Supervisor) Start() error {
 			if sig == syscall.SIGCHLD {
 				continue
 			}
-			err := s.cmd.Process.Signal(sig)
-			if err != nil {
-				log.Printf("Signal propegation failed: %v\n", err)
+			// Test that process still exists
+			if err := s.cmd.Process.Signal(syscall.Signal(0)); err == nil {
+				err := s.cmd.Process.Signal(sig)
+				if err != nil {
+					log.Printf("Signal propegation failed: %v\n", err)
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
Didn't realise to keep the error on this one unfortunately but this change fixes an edgecase where eg. Kubernetes signals the process to exit but its already gone at that point.

Using signal `0` means we just test if the process is still there and then when can proceed to give pipe in the actual signal we go